### PR TITLE
SVCPLAN-7444: Add kvm class to support qemu_guest_agent

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,6 +7,7 @@
 ### Classes
 
 * [`profile_virtual`](#profile_virtual): Host customization depending on virtualization hypervisor type
+* [`profile_virtual::kvm`](#profile_virtual--kvm): Host customization if running on a KVM hypervisor
 * [`profile_virtual::physical`](#profile_virtual--physical): Host customization if running on a physical server
 * [`profile_virtual::vmware`](#profile_virtual--vmware): Host customization if running on a VMware hypervisor
 
@@ -23,6 +24,48 @@ Host customization depending on virtualization hypervisor type
 ```puppet
 include profile_virtual
 ```
+
+### <a name="profile_virtual--kvm"></a>`profile_virtual::kvm`
+
+Host customization if running on a KVM hypervisor
+Currently this only makes changes for QEMU virtual hosts
+
+NOTE: For QEMU VMs qemu_guest_agent needs to be enabled for the VM in the hypervisor.
+Enabling the qemu_guest_agent option creates a special device that the VM host has access to.
+
+#### Examples
+
+##### 
+
+```puppet
+include profile_virtual::kvm
+```
+
+#### Parameters
+
+The following parameters are available in the `profile_virtual::kvm` class:
+
+* [`files_remove_setuid`](#-profile_virtual--kvm--files_remove_setuid)
+* [`qemu_packages`](#-profile_virtual--kvm--qemu_packages)
+* [`qemu_services`](#-profile_virtual--kvm--qemu_services)
+
+##### <a name="-profile_virtual--kvm--files_remove_setuid"></a>`files_remove_setuid`
+
+Data type: `Hash`
+
+Hash of file resource parameters that need setuid removed from them
+
+##### <a name="-profile_virtual--kvm--qemu_packages"></a>`qemu_packages`
+
+Data type: `Array[String[1]]`
+
+Array of packages to ensure installed for qemu
+
+##### <a name="-profile_virtual--kvm--qemu_services"></a>`qemu_services`
+
+Data type: `Array[String[1]]`
+
+Array of services to ensure running for qemu
 
 ### <a name="profile_virtual--physical"></a>`profile_virtual::physical`
 
@@ -60,7 +103,7 @@ The following parameters are available in the `profile_virtual::vmware` class:
 
 Data type: `Hash`
 
-Hash of file resource paramters that need setuid removed from them
+Hash of file resource parameters that need setuid removed from them
 
 ##### <a name="-profile_virtual--vmware--packages"></a>`packages`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,3 +1,9 @@
 ---
+profile_virtual::kvm::files_remove_setuid: {}
+profile_virtual::kvm::qemu_packages:
+  - "qemu-guest-agent"
+profile_virtual::kvm::qemu_services:
+  - "qemu-guest-agent"
+
 profile_virtual::vmware::files_remove_setuid:
   "/bin/fusermount": {}

--- a/lib/facter/qemu_guest_agent.rb
+++ b/lib/facter/qemu_guest_agent.rb
@@ -1,0 +1,5 @@
+Facter.add('qemu_guest_agent') do
+  setcode do
+    File.exist?('/dev/virtio-ports/org.qemu.guest_agent.0')
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,11 +6,17 @@
 #   include profile_virtual
 class profile_virtual {
   case $facts['virtual'] {
-    'vmware': {
-      include profile_virtual::vmware
+    'kvm': {
+      include profile_virtual::kvm
     }
     'physical': {
       include profile_virtual::physical
+    }
+    'qemu': {
+      include profile_virtual::kvm
+    }
+    'vmware': {
+      include profile_virtual::vmware
     }
     default:  {
       ## DO NOT DO ANYTHING
@@ -18,5 +24,5 @@ class profile_virtual {
   }
 
   # OTHER POSSIBLE virtual FACT VALUES:
-  # 'virtualbox', 'kvm', 'openstack', hyperv, qemu, xen, etc.
+  # 'virtualbox', 'openstack', hyperv, xen, etc.
 }

--- a/manifests/kvm.pp
+++ b/manifests/kvm.pp
@@ -1,0 +1,61 @@
+# @summary Host customization if running on a KVM hypervisor
+#
+# Host customization if running on a KVM hypervisor
+# Currently this only makes changes for QEMU virtual hosts
+#
+# NOTE: For QEMU VMs qemu_guest_agent needs to be enabled for the VM in the hypervisor.
+# Enabling the qemu_guest_agent option creates a special device that the VM host has access to.
+#
+# @param files_remove_setuid
+#   Hash of file resource parameters that need setuid removed from them
+#
+# @param qemu_packages
+#   Array of packages to ensure installed for qemu
+#
+# @param qemu_services
+#   Array of services to ensure running for qemu
+#
+# @example
+#   include profile_virtual::kvm
+class profile_virtual::kvm (
+  Hash             $files_remove_setuid,
+  Array[String[1]] $qemu_packages,
+  Array[String[1]] $qemu_services,
+) {
+  $hw_array = split($facts['dmi']['manufacturer'], Regexp['[\s,]'])
+  $hardware = $hw_array[0]
+
+  case $hardware {
+    /(?i)qemu/: {
+      # CAN ONLY RUN qemu_guest_agent IF 'QEMU Guest Agent' OPTION ENABLED ON THE VM
+      # IN PROXMOX THIS REQUIRES ENABLING IT UNDER EACH VM'S OPTIONS
+      if $facts['qemu_guest_agent'] {
+        # INSTALL $qemu_packages
+        ensure_packages(
+          $qemu_packages,
+          { 'notify' => Service[$qemu_services], }
+        )
+
+        # ENABLE $qemu_services
+        service { $qemu_services:
+          ensure     => running,
+          enable     => true,
+          hasstatus  => true,
+          hasrestart => true,
+        }
+      } else {
+        notify { 'QEMU guest agent device is not present in this VM. You should enable it in the VMs hypervisor.': }
+      }
+    }
+    default:  {
+      ## DO NOT DO ANYTHING
+      ## CURRENTLY WE HAVE NO CONFIGURATION FOR OTHER TYPES OF KVM VMS
+    }
+  }
+
+  # Remove setuid/setgid from key files
+  $file_remove_setuid_defaults = {
+    mode    => 'ug-s',
+  }
+  ensure_resources('file', $files_remove_setuid, $file_remove_setuid_defaults )
+}

--- a/manifests/vmware.pp
+++ b/manifests/vmware.pp
@@ -3,7 +3,7 @@
 # Host customization if running on a VMware hypervisor
 #
 # @param files_remove_setuid
-#   Hash of file resource paramters that need setuid removed from them
+#   Hash of file resource parameters that need setuid removed from them
 #
 # @param packages
 #   Array of packages to ensure installed for vmware

--- a/spec/classes/kvm_spec.rb
+++ b/spec/classes/kvm_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile_virtual::kvm' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile.with_all_deps }
+    end
+  end
+end


### PR DESCRIPTION
Fix #5 

This has been tested successfully on `cc-pup01`, `cc-sched-test`, `cc-test03` (physical node), & `cc-test04`.

In order for `qemu_guest_agent` service to run, the KVM hypervisor (e.g. Proxmox) needs to specifically set the VM with an option to enable a QEMU Guest Agent device (`/dev/virtio-ports/org.qemu.guest_agent.0`). This is annoying for VMs that have already been created. Currently this puppet module will post a notification in the Puppet run if the host is a QEMU VM but has not been configured with the QEMU Guest Agent device:
```
Notice: QEMU guest agent device is not present in this VM. You should enable it in the VMs hypervisor.
```
I'd like feedback if that is OK, needs the message changed, or if we want it not bother notifying about it.